### PR TITLE
Modernize Faraday integration and bump version to 0.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 os: linux
-dist: trusty
+dist: xenial
 language: ruby
 cache: bundler
 rvm:
   - 2.4.10
-before_install: gem install bundler -v 1.17.3
+before_install:
+  - gem install bundler -v 1.17.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-07-15
+
+### Changed
+- Modernized `PopEngine::Client` connection syntax to use `conn.request :basic_auth` instead of the deprecated `conn.basic_auth` helper method.
+- Tightened Faraday version constraints in `pop_engine.gemspec` to target `>= 1.0, < 3.0`, dropping support for legacy Faraday 0.x.
+
+## [0.1.0] - 2025-11-12
+- Initial release of the `pop-engine` gem for communicating with the PopEngine API.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,15 @@
 PATH
   remote: .
   specs:
-    pop_engine (0.1.0)
-      faraday (>= 0.9, < 3.0)
+    pop_engine (0.2.0)
+      faraday (>= 1.0, < 3.0)
       json (~> 2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.5.1)
-    faraday (1.10.3)
+    faraday (1.10.6)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -22,17 +22,17 @@ GEM
       faraday-retry (~> 1.0)
       ruby2_keywords (>= 0.0.4)
     faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
+    faraday-em_synchrony (1.0.1)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
-    faraday-net_http (1.0.1)
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
+    faraday-net_http (1.0.2)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
-    json (2.7.2)
+    faraday-retry (1.0.4)
+    json (2.7.6)
     multipart-post (2.3.0)
     rake (10.5.0)
     rspec (3.13.0)

--- a/lib/pop_engine/client.rb
+++ b/lib/pop_engine/client.rb
@@ -24,7 +24,7 @@ module PopEngine
 
     def connection
       @connection ||= Faraday.new(API_URL) do |conn|
-        conn.basic_auth(username, password)
+        conn.request :basic_auth, username, password
         conn.headers['Content-Type'] = 'application/json'
         conn.adapter adapter, @stubs
       end

--- a/lib/pop_engine/version.rb
+++ b/lib/pop_engine/version.rb
@@ -1,3 +1,3 @@
 module PopEngine
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.2.0'.freeze
 end

--- a/pop_engine.gemspec
+++ b/pop_engine.gemspec
@@ -28,10 +28,11 @@ Gem::Specification.new do |spec|
 
   spec.metadata['source_code_uri'] = 'https://github.com/talentnest/pop-engine'
   spec.metadata['bug_tracker_uri'] = 'https://github.com/talentnest/pop-engine/issues'
+  spec.metadata["changelog_uri"] = "https://github.com/talentnest/pop-engine/blob/main/CHANGELOG.md"
 
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
 
   spec.add_dependency 'json', '~> 2.0'
-  spec.add_dependency 'faraday', '>= 0.9', '< 3.0'
+  spec.add_dependency 'faraday', '>= 1.0', '< 3.0'
 end


### PR DESCRIPTION
- Update `PopEngine::Client` to use `conn.request :basic_auth` middleware syntax to resolve 1.x deprecations.
- Tighten gemspec constraints to require faraday >= 1.0, < 3.0.
- Add `CHANGELOG.md` and link it in the gemspec metadata.